### PR TITLE
10 add salary dto and change salaru feilde in vacancy dto

### DIFF
--- a/src/main/java/com/example/vacancyimportservice/config/RabbitmqConfig.java
+++ b/src/main/java/com/example/vacancyimportservice/config/RabbitmqConfig.java
@@ -1,6 +1,7 @@
 package com.example.vacancyimportservice.config;
 
-import org.springframework.amqp.core.*;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
@@ -14,9 +15,6 @@ public class RabbitmqConfig {
     @Value("${rabbitmq.vacancies_queue}")
     private String vacanciesQueue;
 
-    @Value("${rabbitmq.vacancies_imported_exchange}")
-    private String vacanciesImportedExchange;
-
     @Bean
     public MessageConverter jsonMessageConvertor() {
         return new Jackson2JsonMessageConverter();
@@ -27,19 +25,6 @@ public class RabbitmqConfig {
         return new Queue(vacanciesQueue);
     }
 
-    @Bean
-    public DirectExchange exchange() {
-        return new DirectExchange(vacanciesImportedExchange);
-    }
-
-    @Bean
-    public Binding binding() {
-        return BindingBuilder
-                .bind(queue())
-                .to(exchange())
-                .with("");
-
-    }
     @Bean
     public AmqpTemplate amqpTemplate(ConnectionFactory connectionFactory) {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);

--- a/src/main/java/com/example/vacancyimportservice/dto/hh/Salary.java
+++ b/src/main/java/com/example/vacancyimportservice/dto/hh/Salary.java
@@ -1,0 +1,48 @@
+package com.example.vacancyimportservice.dto.hh;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Salary {
+    @JsonProperty("from")
+    private int from;
+    @JsonProperty("to")
+    private int to;
+    @JsonProperty("currency")
+    private String currency;
+    @JsonProperty("gross")
+    private boolean gross;
+    @JsonProperty("from")
+    public int getFrom() {
+        return from;
+    }
+
+    public void setFrom(int from) {
+        this.from = from;
+    }
+    @JsonProperty("to")
+    public int getTo() {
+        return to;
+    }
+
+    public void setTo(int to) {
+        this.to = to;
+    }
+    @JsonProperty("currency")
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+    @JsonProperty("gross")
+    public boolean isGross() {
+        return gross;
+    }
+
+    public void setGross(boolean gross) {
+        this.gross = gross;
+    }
+}

--- a/src/main/java/com/example/vacancyimportservice/dto/hh/Vacancy.java
+++ b/src/main/java/com/example/vacancyimportservice/dto/hh/Vacancy.java
@@ -15,7 +15,7 @@ public class Vacancy {
     @JsonProperty("area")
     private Area area;
     @JsonProperty("salary")
-    private Object salary;
+    private Salary salary;
     @JsonProperty("type")
     private Type type;
     @JsonProperty("response_url")
@@ -71,12 +71,12 @@ public class Vacancy {
     }
 
     @JsonProperty("salary")
-    public Object getSalary() {
+    public Salary getSalary() {
         return salary;
     }
 
     @JsonProperty("salary")
-    public void setSalary(Object salary) {
+    public void setSalary(Salary salary) {
         this.salary = salary;
     }
 

--- a/src/main/java/com/example/vacancyimportservice/service/ProduceService.java
+++ b/src/main/java/com/example/vacancyimportservice/service/ProduceService.java
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class ProduceService {
-    @Value("${rabbitmq.vacancies_imported_exchange}")
-    private String vacanciesImportedExchange;
+    @Value("${rabbitmq.vacancies_queue}")
+    private String vacanciesQueue;
     private final RabbitTemplate rabbitTemplate;
 
     public ProduceService(RabbitTemplate rabbitTemplate) {
@@ -16,6 +16,6 @@ public class ProduceService {
     }
 
     public void publishVacancy(Vacancy vacancy) {
-        rabbitTemplate.convertAndSend(vacanciesImportedExchange,"",vacancy);
+        rabbitTemplate.convertAndSend(vacanciesQueue, vacancy);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,6 @@ spring:
 
 rabbitmq:
   vacancies_queue: imported-vacancies-queue
-  vacancies_imported_exchange: imported-vacancies-exchange
   vacancy_import_scheduled_tasks_queue: vacancy-import-scheduled-tasks-queue
 
 api:


### PR DESCRIPTION
Удалили exchange для imported-vacancies-queue.
Создавал этот exchange чтобы добавить сообщение, теперь использую имя очереди как routing_key 